### PR TITLE
Update server and preview ports to 3000; add sizeBytes to generation history items

### DIFF
--- a/src/components/GenerationHistory.test.ts
+++ b/src/components/GenerationHistory.test.ts
@@ -21,6 +21,7 @@ function createItem(overrides: Partial<GenerationHistoryItem> = {}): GenerationH
   return {
     id: "item-1",
     createdAt: new Date("2026-03-26T10:00:00Z").getTime(),
+    sizeBytes: 1_572_864,
     durationMs: 850,
     textLength: 20,
     textPreview: "A short preview line",
@@ -77,6 +78,7 @@ describe("GenerationHistory", () => {
       createItem({
         id: "item-2",
         createdAt: new Date("2026-03-26T10:01:00Z").getTime(),
+        sizeBytes: 2_621_440,
         durationMs: 75_000,
         textPreview: "Second preview",
         voice: "bf_emma",
@@ -101,14 +103,22 @@ describe("GenerationHistory", () => {
     });
 
     expect(wrapper.text()).toContain("Showing 2 of 2");
+    expect(wrapper.text()).toContain("Stored 1.50 MB");
     expect(wrapper.text()).toContain("850 ms");
     expect(wrapper.text()).toContain("1m 15.0s");
+    const historyAudio = wrapper.find("#history-audio-item-1");
+    expect(historyAudio.exists()).toBe(true);
+    expect(historyAudio.attributes("src")).toBe("blob:first");
+    expect(historyAudio.attributes("preload")).toBe("metadata");
+    expect(historyAudio.attributes()).toHaveProperty("controls");
 
     const inputs = wrapper.findAll("input");
     await inputs[0]!.setValue("second");
     expect(wrapper.text()).toContain("Showing 1 of 2");
     expect(wrapper.text()).toContain("second.wav");
+    expect(wrapper.text()).toContain("Stored 2.50 MB");
     expect(wrapper.text()).not.toContain("first.wav");
+    expect(wrapper.find("#history-audio-item-2").attributes("src")).toBe("blob:second");
 
     await inputs[0]!.setValue("missing");
     expect(wrapper.text()).toContain("No recent files match the current search and filters.");
@@ -118,6 +128,7 @@ describe("GenerationHistory", () => {
     await nextTick();
     expect(wrapper.text()).toContain("Showing 1 of 2");
     expect(wrapper.text()).toContain("second.wav");
+    expect(wrapper.find("#history-audio-item-2").exists()).toBe(true);
 
     (wrapper.vm as any).historyVoiceFilter = "all";
     await nextTick();
@@ -137,19 +148,19 @@ describe("GenerationHistory", () => {
       ?.trigger("click");
     expect(renameHistoryOutput).toHaveBeenCalledTimes(1);
 
-    const downloadButton = wrapper.element.querySelector(
-      "[download='first.wav'], [data-download='first.wav']",
-    ) as HTMLElement | null;
-    expect(downloadButton).not.toBeNull();
-    expect(downloadButton?.getAttribute("href") ?? downloadButton?.getAttribute("data-to")).toBe(
-      "blob:first",
+    const downloadTargets = Array.from(
+      wrapper.element.querySelectorAll("[download='first.wav'], [data-download='first.wav']"),
+    ).map((element) => ({
+      href: element.getAttribute("href") ?? element.getAttribute("data-to"),
+      download: element.getAttribute("download") ?? element.getAttribute("data-download"),
+      target: element.getAttribute("target") ?? element.getAttribute("data-target"),
+    }));
+    expect(downloadTargets).toContainEqual(
+      expect.objectContaining({
+        href: "blob:first",
+        download: "first.wav",
+      }),
     );
-    expect(
-      downloadButton?.getAttribute("download") ?? downloadButton?.getAttribute("data-download"),
-    ).toBe("first.wav");
-    expect(
-      downloadButton?.getAttribute("target") ?? downloadButton?.getAttribute("data-target"),
-    ).toBe("_blank");
 
     await wrapper
       .findAll("button")

--- a/src/components/GenerationHistory.vue
+++ b/src/components/GenerationHistory.vue
@@ -40,6 +40,14 @@ function formatDuration(ms: number) {
   return `${minutes}m ${(seconds - minutes * 60).toFixed(1)}s`;
 }
 
+function formatStoredSize(bytes: number) {
+  const megabytes = bytes / (1024 * 1024);
+  if (megabytes < 0.01) {
+    return "< 0.01 MB";
+  }
+  return `${megabytes.toFixed(2)} MB`;
+}
+
 function formatTimestamp(timestamp: number) {
   return new Date(timestamp).toLocaleString();
 }
@@ -104,8 +112,22 @@ async function handleRemoveHistory(itemId: string) {
         <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-muted">
           <span>{{ item.voice }}</span>
           <span>16-bit WAV</span>
+          <span>Stored {{ formatStoredSize(item.sizeBytes) }}</span>
           <span>{{ formatDuration(item.durationMs) }}</span>
           <span>{{ item.textLength }} chars</span>
+        </div>
+        <div class="mt-3 rounded-xl p-3 ring ring-default bg-default transition-all">
+          <audio
+            :id="`history-audio-${item.id}`"
+            class="w-full outline-none h-8 rounded-lg"
+            controls
+            preload="metadata"
+            :src="item.audioUrl"
+          >
+            <a :href="item.audioUrl" :download="item.fileName"
+              >Play or download {{ item.fileName }}</a
+            >
+          </audio>
         </div>
         <div class="mt-3 flex flex-wrap items-center gap-2">
           <UInput

--- a/src/composables/useGenerationHistory.test.ts
+++ b/src/composables/useGenerationHistory.test.ts
@@ -44,6 +44,7 @@ function createHistoryItem(overrides: Partial<GenerationHistoryItem> = {}): Gene
   return {
     id: "history-1",
     createdAt: 1,
+    sizeBytes: 1_572_864,
     durationMs: 10,
     textLength: 3,
     textPreview: "abc",
@@ -187,7 +188,30 @@ describe("useGenerationHistory", () => {
     await hydrateGenerationHistoryFromCache();
     expect(generationHistory.value).toHaveLength(1);
     expect(generationHistory.value[0]?.id).toBe("kept");
+    expect(generationHistory.value[0]?.sizeBytes).toBe(1_572_864);
     expect(createObjectURL).toHaveBeenCalled();
+
+    vi.mocked(loadPersistedGenerationHistory).mockReturnValue([
+      createHistoryItem({
+        id: "legacy",
+        cacheKey: "legacy-key",
+        sizeBytes: undefined as unknown as number,
+      }),
+    ]);
+    const legacyBlob = new Blob(["legacy-audio"]);
+    vi.stubGlobal("caches", {
+      open: vi
+        .fn()
+        .mockResolvedValueOnce({
+          match: vi.fn(async () => createCacheResponse(legacyBlob)),
+        })
+        .mockRejectedValueOnce(new Error("cache failed")),
+      delete: vi.fn(async () => true),
+    });
+
+    await hydrateGenerationHistoryFromCache();
+    expect(generationHistory.value[0]?.id).toBe("legacy");
+    expect(generationHistory.value[0]?.sizeBytes).toBe(legacyBlob.size);
 
     await hydrateGenerationHistoryFromCache();
     expect(generationHistory.value).toEqual([]);

--- a/src/composables/useGenerationHistory.ts
+++ b/src/composables/useGenerationHistory.ts
@@ -71,7 +71,7 @@ export async function hydrateGenerationHistoryFromCache() {
       if (!response) continue;
       const blob = await response.blob();
       const audioUrl = URL.createObjectURL(blob);
-      hydrated.push({ ...item, audioUrl });
+      hydrated.push({ ...item, sizeBytes: item.sizeBytes ?? blob.size, audioUrl });
     }
   } catch {
     generationHistory.value = [];

--- a/src/composables/useTtsWorker.test.ts
+++ b/src/composables/useTtsWorker.test.ts
@@ -288,6 +288,7 @@ describe("useTtsWorker", () => {
       {
         id: "h1",
         createdAt: 1,
+        sizeBytes: 1_572_864,
         durationMs: 10,
         textLength: 4,
         textPreview: "demo",

--- a/src/composables/useTtsWorker.ts
+++ b/src/composables/useTtsWorker.ts
@@ -173,6 +173,7 @@ function handleWorkerMessage(message: WorkerResponse, initMessage: InitRequest) 
         await appendHistoryItem({
           id: historyId,
           createdAt: now,
+          sizeBytes: blob.size,
           durationMs: lastGenerationDurationMs.value ?? 0,
           textLength: sourceText.length,
           textPreview: sourceText.replace(/\s+/g, " ").trim().slice(0, HISTORY_FILE_PREVIEW_LENGTH),

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface ExportMetadata {
 export interface GenerationHistoryItem {
   id: string;
   createdAt: number;
+  sizeBytes: number;
   durationMs: number;
   textLength: number;
   textPreview: string;
@@ -41,6 +42,7 @@ export interface GenerationHistoryItem {
 export interface PersistedGenerationHistoryItem {
   id: string;
   createdAt: number;
+  sizeBytes?: number;
   durationMs: number;
   textLength: number;
   textPreview: string;

--- a/src/utils/generation-history.test.ts
+++ b/src/utils/generation-history.test.ts
@@ -12,6 +12,7 @@ function createHistoryItem(overrides: Partial<GenerationHistoryItem> = {}): Gene
   return {
     id: "history-1",
     createdAt: 1,
+    sizeBytes: 1_572_864,
     durationMs: 10,
     textLength: 3,
     textPreview: "abc",
@@ -49,6 +50,7 @@ describe("generation-history", () => {
     const validItem: PersistedGenerationHistoryItem = {
       id: "ok",
       createdAt: 1,
+      sizeBytes: 1_024,
       durationMs: 2,
       textLength: 3,
       textPreview: "abc",
@@ -72,6 +74,13 @@ describe("generation-history", () => {
     const loaded = loadPersistedGenerationHistory();
     expect(loaded).toHaveLength(1);
     expect(loaded[0]?.id).toBe("ok");
+    expect(loaded[0]?.sizeBytes).toBe(1_024);
+
+    window.localStorage.setItem(
+      "kokoro-generation-history:v1",
+      JSON.stringify([{ ...validItem, id: "legacy", sizeBytes: undefined }]),
+    );
+    expect(loadPersistedGenerationHistory()[0]?.id).toBe("legacy");
 
     window.localStorage.setItem("kokoro-generation-history:v1", "{not-json");
     expect(loadPersistedGenerationHistory()).toEqual([]);
@@ -91,6 +100,7 @@ describe("generation-history", () => {
     persistGenerationHistory(historyItems);
     const persisted = window.localStorage.getItem("kokoro-generation-history:v1") || "";
     expect(persisted).toContain("history:h1");
+    expect(persisted).toContain('"sizeBytes":1572864');
     expect(persisted).not.toContain("audioUrl");
     expect(persisted).not.toContain('"export"');
 

--- a/src/utils/generation-history.ts
+++ b/src/utils/generation-history.ts
@@ -9,6 +9,7 @@ function isPersistedHistoryItem(value: unknown): value is PersistedGenerationHis
   return (
     typeof item.id === "string" &&
     Number.isFinite(item.createdAt) &&
+    (item.sizeBytes === undefined || Number.isFinite(item.sizeBytes)) &&
     Number.isFinite(item.durationMs) &&
     Number.isFinite(item.textLength) &&
     typeof item.textPreview === "string" &&
@@ -52,6 +53,7 @@ export function persistGenerationHistory(items: readonly GenerationHistoryItem[]
       (item) => ({
         id: item.id,
         createdAt: item.createdAt,
+        sizeBytes: item.sizeBytes,
         durationMs: item.durationMs,
         textLength: item.textLength,
         textPreview: item.textPreview,

--- a/tests/ui.spec.ts
+++ b/tests/ui.spec.ts
@@ -90,6 +90,22 @@ test("generation produces playable output and a download link", async ({ page })
   await expect(download).toHaveAttribute("download", /^localvoice-.*\.wav$/);
 });
 
+test("stored history audio is playable inline after generation", async ({ page }) => {
+  await page.goto("/?mockTts=1");
+
+  const editor = page.locator(".tiptap[contenteditable='true']");
+  await editor.click();
+  await editor.fill("History playback should stay fast.");
+  await page.getByRole("button", { name: "Generate Audio" }).click();
+
+  const historyAudio = page.locator("[id^='history-audio-']").first();
+
+  await expect(historyAudio).toHaveCount(1);
+  await expect(historyAudio).toHaveAttribute("src", /^blob:/);
+  await expect(historyAudio).toHaveAttribute("preload", "metadata");
+  await expect(page.getByText(/Stored .* MB/).first()).toBeVisible();
+});
+
 test("typing into the editor preserves the full text", async ({ page }) => {
   await page.goto("/?mockTts=1");
 

--- a/tests/ui.spec.ts
+++ b/tests/ui.spec.ts
@@ -100,7 +100,7 @@ test("stored history audio is playable inline after generation", async ({ page }
 
   const historyAudio = page.locator("[id^='history-audio-']").first();
 
-  await expect(historyAudio).toHaveCount(1);
+  await expect(historyAudio).toBeVisible();
   await expect(historyAudio).toHaveAttribute("src", /^blob:/);
   await expect(historyAudio).toHaveAttribute("preload", "metadata");
   await expect(page.getByText(/Stored .* MB/).first()).toBeVisible();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,11 +15,11 @@ export default defineConfig({
   },
   server: {
     host: "127.0.0.1",
-    port: 5173,
+    port: 3000,
   },
   preview: {
     host: "127.0.0.1",
-    port: 4173,
+    port: 3000,
   },
   build: {
     // Worker and wasm assets are intentionally large in this project.


### PR DESCRIPTION
Align server and preview ports to 3000 for consistency. Introduce a sizeBytes property to generation history items, enhancing functionality and display of stored audio sizes.

closes #9