### PR TITLE
fix: restore release workflow by adding missing conventional preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.4",
         "@vue/test-utils": "^2.4.6",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "jsdom": "^29.0.2",
         "semantic-release": "^25.0.3",
         "typescript": "^6.0.2",
@@ -6835,6 +6836,19 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
       "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.4",
     "@vue/test-utils": "^2.4.6",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "jsdom": "^29.0.2",
     "semantic-release": "^25.0.3",
     "typescript": "^6.0.2",


### PR DESCRIPTION
## Root Cause
The post-merge `Release` workflow failed in `semantic-release` with:

- `Error: Cannot find module 'conventional-changelog-conventionalcommits'`

`@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` are configured with `preset: conventionalcommits`, which requires this package to be installed.

## Fix
- add missing dev dependency:
  - `conventional-changelog-conventionalcommits@^9.3.1`
- update lockfile accordingly

## Validation
- local `semantic-release --dry-run --no-ci` now loads all configured plugins without module errors
- pre-push checks passed:
  - `npm run build`
  - `npm run test:unit`
